### PR TITLE
Panic if MarshalOptions is nil

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -204,6 +204,11 @@ func MarshalStruct(input interface{}, options *MarshalOptions) ([]byte, error) {
 // Marshal is the canonical way to perform the equivalent of serialize() in PHP.
 // It can handle encoding scalar types, slices and maps.
 func Marshal(input interface{}, options *MarshalOptions) ([]byte, error) {
+	
+	if options == nil {
+		options = DefaultMarshalOptions()
+	}
+	
 	// []byte is a special case because all strings (binary and otherwise)
 	// are handled as strings in PHP.
 	if bytesToEncode, ok := input.([]byte); ok {


### PR DESCRIPTION
If you give "nil" as *MarshalOptions, it will result in a panic, when you try to marshal a struct:
`panic: runtime error: invalid memory address or nil pointer dereference`

### [serialize.go:196](https://github.com/elliotchance/phpserialize/blob/master/serialize.go#L196)

```go
	className := reflect.ValueOf(input).Type().Name()
	if options.OnlyStdClass {     //  <== ERROR
		className = "stdClass"
	}
```

### Example:

```go
package main

import (
	"github.com/elliotchance/phpserialize"
	"fmt"
)

type Test struct {
	Value string
}

func main() {
	out, err := phpserialize.Marshal(&Test{Value:"12345"}, nil)
	if err != nil {
		panic(err)
	}

	fmt.Println(string(out))

	var in float64
	err = phpserialize.Unmarshal(out, &in)

	fmt.Println(in)
}
```