### PR TITLE
do not escape strings

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -92,12 +92,6 @@ func MarshalFloat(value float64, bitSize int) []byte {
 //     echo serialize('Hello world');
 //     // s:11:"Hello world";
 //
-// Non ASCII characters will be escaped in the output, so the result will always
-// be an ASCII string:
-//
-//     MarshalString("Björk Guðmundsdóttir");
-//     // s:23:"Bj\xc3\xb6rk Gu\xc3\xb0mundsd\xc3\xb3ttir";
-//
 // The same result would be returned by marshalling a string value:
 //
 //     Marshal('Hello world')
@@ -105,20 +99,7 @@ func MarshalFloat(value float64, bitSize int) []byte {
 // One important distinction is that PHP stores binary data in strings. See
 // MarshalBytes for more information.
 func MarshalString(value string) []byte {
-	var buffer bytes.Buffer
-	for _, r := range value {
-		if r <= 127 {
-			buffer.WriteRune(r)
-		} else {
-			chars := make([]byte, 4)
-			for i := 0; i < utf8.EncodeRune(chars, r); i++ {
-				escapedChar := fmt.Sprintf("\\x%02x", chars[i])
-				buffer.WriteString(escapedChar)
-			}
-		}
-	}
-
-	return []byte(fmt.Sprintf("s:%d:\"%s\";", len(value), buffer.String()))
+	return []byte(fmt.Sprintf("s:%d:\"%s\";", len(value), value))
 }
 
 // MarshalBytes returns the bytes to represent a PHP serialized string value

--- a/serialize.go
+++ b/serialize.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unicode/utf8"
 )
 
 // MarshalOptions must be provided when invoking Marshal(). Use

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -73,7 +73,7 @@ var marshalTests = map[string]marshalTest{
 	},
 	"string: 'Björk Guðmundsdóttir'": {
 		"Björk Guðmundsdóttir",
-		[]byte("s:23:\"Bj\\xc3\\xb6rk Gu\\xc3\\xb0mundsd\\xc3\\xb3ttir\";"),
+		[]byte("s:23:\"Björk Guðmundsdóttir\";"),
 		nil,
 	},
 


### PR DESCRIPTION
Do not escape strings as PHP does not support escaping in serialized string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/phpserialize/6)
<!-- Reviewable:end -->
