### PR TITLE
fix: escape characters

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -88,10 +88,10 @@ func consumeStringRealPart(data []byte, offset int) (string, int, error) {
 	// redundant.
 	offset = newOffset + 1
 
-	s := DecodePHPString(data)
+	s := DecodePHPString(data[offset:length+offset])
 
 	// The +2 is to skip over the final '";'
-	return s[offset: offset+length], offset + length + 2, nil
+	return s, offset + length + 2, nil
 }
 
 func consumeNil(data []byte, offset int) (interface{}, int, error) {

--- a/serialize.go
+++ b/serialize.go
@@ -98,6 +98,10 @@ func MarshalFloat(value float64, bitSize int) []byte {
 // One important distinction is that PHP stores binary data in strings. See
 // MarshalBytes for more information.
 func MarshalString(value string) []byte {
+	// As far as I can tell only the single-quote is escaped. Not even the
+	// backslash itself is escaped. Weird. See escapeTests for more information.
+	value = strings.Replace(value, "'", "\\'", -1)
+
 	return []byte(fmt.Sprintf("s:%d:\"%s\";", len(value), value))
 }
 

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -171,3 +171,17 @@ func TestMarshalFail(t *testing.T) {
 		t.Error(err.Error())
 	}
 }
+
+func TestMarshalEscape(t *testing.T) {
+	for testName, test := range escapeTests {
+		t.Run(testName, func(t *testing.T) {
+			options := phpserialize.DefaultMarshalOptions()
+			result, err := phpserialize.Marshal(test.Unserialized, options)
+			expectErrorToNotHaveOccurred(t, err)
+
+			if test.Serialized != string(result) {
+				t.Errorf("Expected:\n  %#+v\nGot:\n  %#+v", test.Serialized, result)
+			}
+		})
+	}
+}

--- a/unserialize.go
+++ b/unserialize.go
@@ -26,9 +26,26 @@ func DecodePHPString(data []byte) string {
 	var buffer bytes.Buffer
 	for i := 0; i < len(data); i++ {
 		if data[i] == '\\' {
-			b, _ := strconv.ParseInt(string(data[i+2:i+4]), 16, 32)
-			buffer.WriteByte(byte(b))
-			i += 3
+			switch data[i+1] {
+			case 'x':
+				b, _ := strconv.ParseInt(string(data[i+2:i+4]), 16, 32)
+				buffer.WriteByte(byte(b))
+				i += 3
+
+			case 'n':
+				buffer.WriteByte('\n')
+				i++
+
+			case '\'':
+				buffer.WriteByte(data[i+1])
+				i++
+
+			default:
+				// It's a bit annoying but a backlash itself is not escaped. So
+				// if it was not followed by a known character we have to assume
+				// this.
+				buffer.WriteByte('\\')
+			}
 		} else {
 			buffer.WriteByte(data[i])
 		}


### PR DESCRIPTION
Some characters are escaped and some are not. There seems to be no rhyme or reason to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/phpserialize/10)
<!-- Reviewable:end -->
