### PR TITLE
Implemented "php" tags for structs

### DIFF
--- a/consume.go
+++ b/consume.go
@@ -201,6 +201,7 @@ func setField(structFieldValue reflect.Value, value interface{}) error {
 func fillStruct(obj reflect.Value, m map[interface{}]interface{}) error {
 	// structValue := reflect.ValueOf(obj).Elem()
 	// structFieldValue := structValue.FieldByName(name)
+
 	tt := obj.Type()
 	for i := 0; i < obj.NumField(); i++ {
 		field := obj.Field(i)
@@ -213,7 +214,7 @@ func fillStruct(obj reflect.Value, m map[interface{}]interface{}) error {
 		} else if tag != "" {
 			key = tag
 		} else {
-			key = upperCaseFirstLetter(tt.Name())
+			key = lowerCaseFirstLetter(tt.Field(i).Name)
 		}
 		if v, ok := m[key]; ok {
 			setField(field, v)

--- a/consume.go
+++ b/consume.go
@@ -172,7 +172,6 @@ func consumeObjectAsMap(data []byte, offset int) (
 func setField(structFieldValue reflect.Value, value interface{}) error {
 	if !structFieldValue.IsValid() {
 		return nil
-		// return fmt.Errorf("no such field: %s in obj", name)
 	}
 
 	val := reflect.ValueOf(value)
@@ -199,9 +198,6 @@ func setField(structFieldValue reflect.Value, value interface{}) error {
 
 // https://stackoverflow.com/questions/26744873/converting-map-to-struct
 func fillStruct(obj reflect.Value, m map[interface{}]interface{}) error {
-	// structValue := reflect.ValueOf(obj).Elem()
-	// structFieldValue := structValue.FieldByName(name)
-
 	tt := obj.Type()
 	for i := 0; i < obj.NumField(); i++ {
 		field := obj.Field(i)
@@ -220,13 +216,6 @@ func fillStruct(obj reflect.Value, m map[interface{}]interface{}) error {
 			setField(field, v)
 		}
 	}
-
-	// for k, v := range m {
-	// 	err := setField(obj, k.(string), v)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	return nil
 }

--- a/consume.go
+++ b/consume.go
@@ -2,7 +2,6 @@ package phpserialize
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"strconv"
 )
@@ -170,19 +169,10 @@ func consumeObjectAsMap(data []byte, offset int) (
 	return result, offset + 1, nil
 }
 
-func setField(obj interface{}, name string, value interface{}) error {
-	structValue := reflect.ValueOf(obj).Elem()
-
-	// We need to uppercase the first letter for compatibility.
-	// The Marshal() function does the opposite of this.
-	structFieldValue := structValue.FieldByName(upperCaseFirstLetter(name))
-
+func setField(structFieldValue reflect.Value, value interface{}) error {
 	if !structFieldValue.IsValid() {
-		return fmt.Errorf("no such field: %s in obj", name)
-	}
-
-	if !structFieldValue.CanSet() {
-		return fmt.Errorf("cannot set %s field value", name)
+		return nil
+		// return fmt.Errorf("no such field: %s in obj", name)
 	}
 
 	val := reflect.ValueOf(value)
@@ -198,7 +188,7 @@ func setField(obj interface{}, name string, value interface{}) error {
 
 	case reflect.Struct:
 		m := val.Interface().(map[interface{}]interface{})
-		fillStruct(structFieldValue.Addr().Interface(), m)
+		fillStruct(structFieldValue, m)
 
 	default:
 		structFieldValue.Set(val)
@@ -208,18 +198,39 @@ func setField(obj interface{}, name string, value interface{}) error {
 }
 
 // https://stackoverflow.com/questions/26744873/converting-map-to-struct
-func fillStruct(obj interface{}, m map[interface{}]interface{}) error {
-	for k, v := range m {
-		err := setField(obj, k.(string), v)
-		if err != nil {
-			return err
+func fillStruct(obj reflect.Value, m map[interface{}]interface{}) error {
+	// structValue := reflect.ValueOf(obj).Elem()
+	// structFieldValue := structValue.FieldByName(name)
+	tt := obj.Type()
+	for i := 0; i < obj.NumField(); i++ {
+		field := obj.Field(i)
+		if !field.CanSet() {
+			continue
+		}
+		var key string
+		if tag := tt.Field(i).Tag.Get("php"); tag == "-" {
+			continue
+		} else if tag != "" {
+			key = tag
+		} else {
+			key = upperCaseFirstLetter(tt.Name())
+		}
+		if v, ok := m[key]; ok {
+			setField(field, v)
 		}
 	}
+
+	// for k, v := range m {
+	// 	err := setField(obj, k.(string), v)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }
 
-func consumeObject(data []byte, offset int, v interface{}) (int, error) {
+func consumeObject(data []byte, offset int, v reflect.Value) (int, error) {
 	if !checkType(data, 'O', offset) {
 		return -1, errors.New("not an object")
 	}

--- a/example/test.go
+++ b/example/test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/dasjott/phpserialize"
+	"github.com/elliotchance/phpserialize"
 )
 
 func main() {

--- a/example/test.go
+++ b/example/test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/elliotchance/phpserialize"
 	"fmt"
+	"github.com/dasjott/phpserialize"
 )
 
 func main() {

--- a/serialize.go
+++ b/serialize.go
@@ -165,7 +165,12 @@ func MarshalStruct(input interface{}, options *MarshalOptions) ([]byte, error) {
 		// with an uppercase letter) we must change it to lower case. If
 		// you really do want it to be upper case you will have to wait
 		// for when tags are supported on individual fields.
-		fieldName := lowerCaseFirstLetter(typeOfValue.Field(i).Name)
+		fieldName := typeOfValue.Field(i).Tag.Get("php")
+		if fieldName == "-" {
+			continue
+		} else if fieldName == "" {
+			fieldName = lowerCaseFirstLetter(typeOfValue.Field(i).Name)
+		}
 		buffer.Write(MarshalString(fieldName))
 
 		m, err := Marshal(f.Interface(), options)
@@ -188,11 +193,11 @@ func MarshalStruct(input interface{}, options *MarshalOptions) ([]byte, error) {
 // Marshal is the canonical way to perform the equivalent of serialize() in PHP.
 // It can handle encoding scalar types, slices and maps.
 func Marshal(input interface{}, options *MarshalOptions) ([]byte, error) {
-	
+
 	if options == nil {
 		options = DefaultMarshalOptions()
 	}
-	
+
 	// []byte is a special case because all strings (binary and otherwise)
 	// are handled as strings in PHP.
 	if bytesToEncode, ok := input.([]byte); ok {

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,7 +1,7 @@
 package phpserialize_test
 
 import (
-	"github.com/elliotchance/phpserialize"
+	"github.com/dasjott/phpserialize"
 	"reflect"
 	"testing"
 )
@@ -11,6 +11,14 @@ type struct1 struct {
 	Bar    Struct2
 	hidden bool
 	Baz    string
+}
+
+type structTag struct {
+	Foo     Struct2 `php:"bar"`
+	Bar     int     `php:"foo"`
+	hidden  bool
+	Balu    string `php:"baz"`
+	Ignored string `php:"-"`
 }
 
 type Struct2 struct {
@@ -122,6 +130,13 @@ var marshalTests = map[string]marshalTest{
 	"&struct1{Foo int, Bar Struct2{Qux float64}, hidden bool}": {
 		&struct1{20, Struct2{7.89}, false, "yay"},
 		[]byte("O:7:\"struct1\":3:{s:3:\"foo\";i:20;s:3:\"bar\";O:7:\"Struct2\":1:{s:3:\"qux\";d:7.89;}s:3:\"baz\";s:3:\"yay\";}"),
+		nil,
+	},
+
+	// encode object (struct with tags)
+	"structTag{Bar int, Foo Struct2{Qux float64}, hidden bool, Balu string}": {
+		structTag{Struct2{1.23}, 10, true, "yay", ""},
+		[]byte("O:9:\"structTag\":4:{s:3:\"bar\";O:7:\"Struct2\":1:{s:3:\"qux\";d:1.23;}s:3:\"foo\";i:10;s:3:\"baz\";s:3:\"yay\";}"),
 		nil,
 	},
 

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,7 +1,7 @@
 package phpserialize_test
 
 import (
-	"github.com/dasjott/phpserialize"
+	"github.com/elliotchance/phpserialize"
 	"reflect"
 	"testing"
 )

--- a/unserialize.go
+++ b/unserialize.go
@@ -113,7 +113,7 @@ func UnmarshalAssociativeArray(data []byte) (map[interface{}]interface{}, error)
 	return result, err
 }
 
-func UnmarshalObject(data []byte, v interface{}) error {
+func UnmarshalObject(data []byte, v reflect.Value) error {
 	_, err := consumeObject(data, 0, v)
 	return err
 }
@@ -122,8 +122,7 @@ func Unmarshal(data []byte, v interface{}) error {
 	value := reflect.ValueOf(v).Elem()
 
 	switch value.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
-		reflect.Int64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v, err := UnmarshalInt(data)
 		if err != nil {
 			return err
@@ -195,7 +194,7 @@ func Unmarshal(data []byte, v interface{}) error {
 		return nil
 
 	case reflect.Struct:
-		err := UnmarshalObject(data, v)
+		err := UnmarshalObject(data, value)
 		if err != nil {
 			return err
 		}

--- a/unserialize_test.go
+++ b/unserialize_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/dasjott/phpserialize"
+	"github.com/elliotchance/phpserialize"
 )
 
 func expectErrorToNotHaveOccurred(t *testing.T, err error) {

--- a/unserialize_test.go
+++ b/unserialize_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elliotchance/phpserialize"
+	"github.com/dasjott/phpserialize"
 )
 
 func expectErrorToNotHaveOccurred(t *testing.T, err error) {
@@ -496,6 +496,29 @@ func TestUnmarshalObject(t *testing.T) {
 
 	if result.Baz != "yay" {
 		t.Errorf("Expected %v, got %v", "yay", result.Baz)
+	}
+}
+
+func TestUnmarshalObjectWithTags(t *testing.T) {
+	data := "O:7:\"struct1\":3:{s:3:\"foo\";i:10;s:3:\"bar\";O:7:\"Struct2\":1:{s:3:\"qux\";d:1.23;}s:3:\"baz\";s:3:\"yay\";}"
+	var result structTag
+	err := phpserialize.Unmarshal([]byte(data), &result)
+	expectErrorToNotHaveOccurred(t, err)
+
+	if result.Bar != 10 {
+		t.Errorf("Expected %v, got %v", 10, result.Bar)
+	}
+
+	if result.Foo.Qux != 1.23 {
+		t.Errorf("Expected %v, got %v", 1.23, result.Foo.Qux)
+	}
+
+	if result.Balu != "yay" {
+		t.Errorf("Expected %v, got %v", "yay", result.Balu)
+	}
+
+	if result.Ignored != "" {
+		t.Errorf("Expected %v, got %v", "yay", result.Ignored)
 	}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -1,7 +1,7 @@
 package phpserialize_test
 
 import (
-	"github.com/dasjott/phpserialize"
+	"github.com/elliotchance/phpserialize"
 	"reflect"
 	"testing"
 )

--- a/util_test.go
+++ b/util_test.go
@@ -1,9 +1,9 @@
 package phpserialize_test
 
 import (
-	"testing"
-	"github.com/elliotchance/phpserialize"
+	"github.com/dasjott/phpserialize"
 	"reflect"
+	"testing"
 )
 
 func TestStringifyKeysOnEmptyMap(t *testing.T) {


### PR DESCRIPTION
If you marshal or unmarshal from/into a struct, you may want to use go tags for it, instead of staticly using the struct field names just changing the first letter to upper/lower case.

Example:

``` go
type Target struct {
    FirstName string `php:"vorname"`
    LastName string  `php:"nachname"`
}
```
This will correctly be filled with the according fields of  serialized php object.
Also unmarshaling will not fail if a struct field does not exist, because you may want to skip some fields from php objects.

I needed this urgently for a project and thought I might provide it.
_Contains unittests_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/phpserialize/20)
<!-- Reviewable:end -->
