### PR TITLE
Add tag option for omitting serialization of nil pointer values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ go get -u github.com/elliotchance/phpserialize
 package main
 
 import (
-	"github.com/elliotchance/phpserialize"
 	"fmt"
+	"github.com/elliotchance/phpserialize"
 )
 
 func main() {
@@ -33,5 +33,39 @@ func main() {
 	err = phpserialize.Unmarshal(out, &in)
 
 	fmt.Println(in)
+}
+```
+
+### Using struct field tags for marshalling
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/elliotchance/phpserialize"
+)
+
+type MyStruct struct {
+	// Will be marhsalled as my_purpose
+	MyPurpose string `php:"my_purpose"`
+	// Will be marshalled as my_motto, and only if not a nil pointer
+	MyMotto *string `php:"my_motto,omitnilptr"`
+	// Will not be marshalled
+	MySecret string `php:"-"`
+}
+
+func main() {
+	my := MyStruct{
+		MyPurpose: "No purpose",
+		MySecret:  "Has a purpose",
+	}
+
+	out, err := phpserialize.Marshal(my, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(out)
 }
 ```

--- a/serialize.go
+++ b/serialize.go
@@ -165,7 +165,14 @@ func MarshalStruct(input interface{}, options *MarshalOptions) ([]byte, error) {
 		// with an uppercase letter) we must change it to lower case. If
 		// you really do want it to be upper case you will have to wait
 		// for when tags are supported on individual fields.
-		fieldName, _ := parseTag(typeOfValue.Field(i).Tag.Get("php"))
+		fieldName, fieldOptions := parseTag(typeOfValue.Field(i).Tag.Get("php"))
+
+		if fieldOptions.Contains("omitnilptr") {
+			if f.Kind() == reflect.Ptr && f.IsNil() {
+				continue
+			}
+		}
+
 		if fieldName == "-" {
 			continue
 		} else if fieldName == "" {

--- a/serialize.go
+++ b/serialize.go
@@ -165,7 +165,7 @@ func MarshalStruct(input interface{}, options *MarshalOptions) ([]byte, error) {
 		// with an uppercase letter) we must change it to lower case. If
 		// you really do want it to be upper case you will have to wait
 		// for when tags are supported on individual fields.
-		fieldName := typeOfValue.Field(i).Tag.Get("php")
+		fieldName, _ := parseTag(typeOfValue.Field(i).Tag.Get("php"))
 		if fieldName == "-" {
 			continue
 		} else if fieldName == "" {

--- a/serialize.go
+++ b/serialize.go
@@ -161,19 +161,17 @@ func MarshalStruct(input interface{}, options *MarshalOptions) ([]byte, error) {
 
 		visibleFieldCount++
 
-		// Note: since we can only export fields that are public (start
-		// with an uppercase letter) we must change it to lower case. If
-		// you really do want it to be upper case you will have to wait
-		// for when tags are supported on individual fields.
 		fieldName, fieldOptions := parseTag(typeOfValue.Field(i).Tag.Get("php"))
 
 		if fieldOptions.Contains("omitnilptr") {
 			if f.Kind() == reflect.Ptr && f.IsNil() {
+				visibleFieldCount--
 				continue
 			}
 		}
 
 		if fieldName == "-" {
+			visibleFieldCount--
 			continue
 		} else if fieldName == "" {
 			fieldName = lowerCaseFirstLetter(typeOfValue.Field(i).Name)

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -17,8 +17,9 @@ type structTag struct {
 	Foo     Struct2 `php:"bar"`
 	Bar     int     `php:"foo"`
 	hidden  bool
-	Balu    string `php:"baz"`
-	Ignored string `php:"-"`
+	Balu    string   `php:"baz"`
+	Ignored string   `php:"-"`
+	Nilptr  *Struct2 `php:",omitnilptr"`
 }
 
 type Struct2 struct {
@@ -134,9 +135,9 @@ var marshalTests = map[string]marshalTest{
 	},
 
 	// encode object (struct with tags)
-	"structTag{Bar int, Foo Struct2{Qux float64}, hidden bool, Balu string}": {
-		structTag{Struct2{1.23}, 10, true, "yay", ""},
-		[]byte("O:9:\"structTag\":4:{s:3:\"bar\";O:7:\"Struct2\":1:{s:3:\"qux\";d:1.23;}s:3:\"foo\";i:10;s:3:\"baz\";s:3:\"yay\";}"),
+	"structTag{Bar int, Foo Struct2{Qux float64}, hidden bool, Balu string, Nilptr <nil>}": {
+		structTag{Struct2{1.23}, 10, true, "yay", "", nil},
+		[]byte("O:9:\"structTag\":3:{s:3:\"bar\";O:7:\"Struct2\":1:{s:3:\"qux\";d:1.23;}s:3:\"foo\";i:10;s:3:\"baz\";s:3:\"yay\";}"),
 		nil,
 	},
 
@@ -166,8 +167,8 @@ func TestMarshal(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(result, test.output) {
-				t.Errorf("Expected '%v', got '%v'", string(result),
-					string(test.output))
+				t.Errorf("Expected '%v', got '%v'", string(test.output),
+					string(result))
 			}
 		})
 	}

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,31 @@
+package phpserialize
+
+import "strings"
+
+type tagOptions string
+
+func parseTag(tag string) (string, tagOptions) {
+	if i := strings.Index(tag, ","); i != -1 {
+		return tag[:i], tagOptions(tag[i+1:])
+	}
+	return tag, ""
+}
+
+func (o tagOptions) Contains(option string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == option {
+			return true
+		}
+		s = next
+	}
+	return false
+}


### PR DESCRIPTION
Current behaviour causes a panic when attempting to serialize structs like the following, whenever `Nilptr` is `nil`:

```go
type Struct1 struct {
	Bar     int     `php:"foo"`
	Balu    string   `php:"baz"`
	Nilptr  *Struct2
}
```

This PR adds the tag option "omitnilptr" to skip serialization of a field if the value is a nil pointer, and also fixes an issue in which phpserialize generates a wrong string when using the "-" tag to ignore fields.

```go
type Struct1 struct {
	Bar     int     `php:"foo"`
	Balu    string   `php:"baz"`
	Nilptr  *Struct2 `php:",omitnilptr"`
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/phpserialize/22)
<!-- Reviewable:end -->
