### PR TITLE
Fix index out of bounds panic

### DIFF
--- a/unserialize.go
+++ b/unserialize.go
@@ -24,7 +24,7 @@ func findByte(data []byte, lookingFor byte, offset int) int {
 // into a UTF8 string ("Björk", in that case).
 func DecodePHPString(data []byte) string {
 	var buffer bytes.Buffer
-	for i := 0; i < len(data); i++ {
+	for i := 0; i < len(data)-1; i++ {
 		if data[i] == '\\' {
 			switch data[i+1] {
 			case 'x':


### PR DESCRIPTION
Previously, `DecodePHPString` could panic on this line due to the index being out bounds: https://github.com/elliotchance/phpserialize/blob/5bb5ecfe1e06ac452fc9ee460c8ae2674465e0ef/unserialize.go#L29

This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/phpserialize/25)
<!-- Reviewable:end -->
