### PR TITLE
support go uint type

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -225,7 +225,7 @@ func Marshal(input interface{}, options *MarshalOptions) ([]byte, error) {
 		reflect.Int64:
 		return MarshalInt(value.Int()), nil
 
-	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return MarshalUint(value.Uint()), nil
 
 	case reflect.Float32:

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -66,6 +66,7 @@ var marshalTests = map[string]marshalTest{
 	"int32: 27": {int32(27), []byte("i:27;"), nil},
 	"int64: 28": {int64(28), []byte("i:28;"), nil},
 
+	"uint: 3":    {uint(3), []byte("i:3;"), nil},
 	"uint8: 4":   {uint8(4), []byte("i:4;"), nil},
 	"uint16: 7":  {uint16(7), []byte("i:7;"), nil},
 	"uint32: 9":  {uint32(9), []byte("i:9;"), nil},

--- a/unserialize.go
+++ b/unserialize.go
@@ -134,7 +134,7 @@ func Unmarshal(data []byte, v interface{}) error {
 
 		value.SetInt(v)
 
-	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		v, err := UnmarshalUint(data)
 		if err != nil {
 			return err

--- a/unserialize_test.go
+++ b/unserialize_test.go
@@ -113,6 +113,20 @@ func TestUnmarshalInt(t *testing.T) {
 				}
 			})
 
+			t.Run("uint", func(t *testing.T) {
+				var result uint
+				err := phpserialize.Unmarshal(test.input, &result)
+
+				if test.expectedError == nil {
+					expectErrorToNotHaveOccurred(t, err)
+					if result != uint(test.output) {
+						t.Errorf("Expected '%v', got '%v'", result, test.output)
+					}
+				} else {
+					expectErrorToEqual(t, err, test.expectedError)
+				}
+			})
+
 			t.Run("uint8", func(t *testing.T) {
 				var result uint8
 				err := phpserialize.Unmarshal(test.input, &result)


### PR DESCRIPTION
enable marshaling and unmarshaling of go `uint` type